### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "retail",
     "name_pretty": "Retail API",
     "product_documentation": "https://cloud.google.com/retail/docs/",
-    "client_documentation": "https://googleapis.dev/python/retail/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/retail/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ machine learning, recommendation system, or Google Cloud.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-retail.svg
    :target: https://pypi.org/project/google-cloud-retail/
 .. _Retail API: https://cloud.google.com/retail/docs
-.. _Client Library Documentation: https://googleapis.dev/python/retail/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/retail/latest
 .. _Product Documentation:  https://cloud.google.com/retail/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.