### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 * suggest search users not to send IP and use hashed user id ([8d61976](https://github.com/googleapis/python-retail/commit/8d619760c771750d55de09fd32deb7e05bf75c8c))
 * users can self enroll retail search feature on cloud console ([8d61976](https://github.com/googleapis/python-retail/commit/8d619760c771750d55de09fd32deb7e05bf75c8c))
 
-### [1.4.1](https://github.com/googleapis/python-retail/compare/v1.4.0...v1.4.1) (2022-03-05)
+## [1.4.1](https://github.com/googleapis/python-retail/compare/v1.4.0...v1.4.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -78,7 +78,7 @@
 
 * update grpc service config settings to reflect correct API deadlines ([#120](https://github.com/googleapis/python-retail/issues/120)) ([e7649c7](https://github.com/googleapis/python-retail/commit/e7649c731ed741e7365dc4b9573dcdd770528929))
 
-### [1.2.1](https://www.github.com/googleapis/python-retail/compare/v1.2.0...v1.2.1) (2021-11-01)
+## [1.2.1](https://www.github.com/googleapis/python-retail/compare/v1.2.0...v1.2.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -114,14 +114,14 @@
 
 * add context manager support in client ([#101](https://www.github.com/googleapis/python-retail/issues/101)) ([3e68d78](https://www.github.com/googleapis/python-retail/commit/3e68d78e6f0c5d2e65f148935446baa92b5dd8ef))
 
-### [1.0.2](https://www.github.com/googleapis/python-retail/compare/v1.0.1...v1.0.2) (2021-09-30)
+## [1.0.2](https://www.github.com/googleapis/python-retail/compare/v1.0.1...v1.0.2) (2021-09-30)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([e82885d](https://www.github.com/googleapis/python-retail/commit/e82885ddcd9926e0b1a5c869e5843c534015b566))
 
-### [1.0.1](https://www.github.com/googleapis/python-retail/compare/v1.0.0...v1.0.1) (2021-09-24)
+## [1.0.1](https://www.github.com/googleapis/python-retail/compare/v1.0.0...v1.0.1) (2021-09-24)
 
 
 ### Bug Fixes
@@ -140,14 +140,14 @@
 
 * Keep the API doc up-to-date ([#80](https://www.github.com/googleapis/python-retail/issues/80)) ([a77f0ea](https://www.github.com/googleapis/python-retail/commit/a77f0ea03ab1d5a2cb976bb2bff3739c15026558))
 
-### [0.4.2](https://www.github.com/googleapis/python-retail/compare/v0.4.1...v0.4.2) (2021-08-04)
+## [0.4.2](https://www.github.com/googleapis/python-retail/compare/v0.4.1...v0.4.2) (2021-08-04)
 
 
 ### Documentation
 
 * **retail:** Quote several literal expressions for better rendering ([#75](https://www.github.com/googleapis/python-retail/issues/75)) ([53ede84](https://www.github.com/googleapis/python-retail/commit/53ede84d0115fc3edfb2deab0203ed9fd9dcbf9d))
 
-### [0.4.1](https://www.github.com/googleapis/python-retail/compare/v0.4.0...v0.4.1) (2021-08-01)
+## [0.4.1](https://www.github.com/googleapis/python-retail/compare/v0.4.0...v0.4.1) (2021-08-01)
 
 
 ### Documentation
@@ -162,7 +162,7 @@
 
 * Add restricted Retail Search features for Retail API v2. ([#68](https://www.github.com/googleapis/python-retail/issues/68)) ([84ba173](https://www.github.com/googleapis/python-retail/commit/84ba173d4eadd75cc5289ce76ee800909b20a5ff))
 
-### [0.3.1](https://www.github.com/googleapis/python-retail/compare/v0.3.0...v0.3.1) (2021-07-26)
+## [0.3.1](https://www.github.com/googleapis/python-retail/compare/v0.3.0...v0.3.1) (2021-07-26)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed.